### PR TITLE
Do not install shiny package from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,4 @@ RUN R -e "install.packages(c('remotes'), repos='https://cloud.r-project.org/')"
 # install package dependencies
 RUN R -e "install.packages(c('magrittr','shiny', 'shinyalert', 'dplyr', 'tidyr', 'rlang', 'yaml', 'lubridate', 'stringr', 'jsonlite'))"
 
-RUN R -e "remotes::install_github('rstudio/shiny')"
-
 CMD ["R"]


### PR DESCRIPTION
Version 1.5.0 on cran now contains what is needed.