### PR TITLE
rm tidyr and lubridate from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get update && apt-get install -y \
 RUN R -e "install.packages(c('remotes'), repos='https://cloud.r-project.org/')"
 
 # install package dependencies
-RUN R -e "install.packages(c('magrittr','shiny', 'shinyalert', 'dplyr', 'tidyr', 'rlang', 'yaml', 'lubridate', 'stringr', 'jsonlite'))"
+RUN R -e "install.packages(c('magrittr','shiny', 'shinyalert', 'dplyr', 'stringr', 'rlang', 'yaml', 'jsonlite'))"
 
 CMD ["R"]


### PR DESCRIPTION
Not needed by qmongr anymore.
Size from 1.4 GB to 1.39 GB